### PR TITLE
Add accessibility attributes to make small button visible

### DIFF
--- a/App.js
+++ b/App.js
@@ -49,9 +49,9 @@ const App: () => Node = () => {
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
           }}>
           <TouchableOpacity
-            style={{ borderWidth: 1, margin: 5, padding: 10, backgroundColor: '#ddd' }}>
+            style={{ borderWidth: 1, margin: 5, padding: 10, backgroundColor: '#ddd' }} accessible={false}>
             <Text>This is the wrapper button </Text>
-            <TouchableOpacity style={{ backgroundColor: 'red', padding: 5, width: '50%', marginTop: 10 }}>
+            <TouchableOpacity style={{ backgroundColor: 'red', padding: 5, width: '50%', marginTop: 10 }} accessible={true}>
               <Text>I'm a small button</Text>
             </TouchableOpacity>
           </TouchableOpacity>


### PR DESCRIPTION
Hey,

I did an experiment to see why the nested button is not visible in the maestro studio. From the [apple documentation](https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/iPhoneAccessibility/Making_Application_Accessible/Making_Application_Accessible.html#//apple_ref/doc/uid/TP40008785-CH102-SW10):

"_If your application displays a custom view that contains other elements with which users interact, you need to make the contained elements separately accessible. At the same time, you need to make sure that the container view itself is not accessible. The reason is that users interact with the contents of the container, not with the container itself._"

Currently state in maestro studio:

![Screenshot 2023-01-16 at 11 14 40 PM](https://user-images.githubusercontent.com/12881364/212739927-2e499e4f-2dc7-4ff6-95db-c27961473cb7.png)

Since we want the inner button accessible through maestro we can make it accessible via [accessible](https://reactnative.dev/docs/accessibility#accessible) attribute. Making this change maestro was able to see the nested component. 

After this change:

![Screenshot 2023-01-16 at 11 16 38 PM](https://user-images.githubusercontent.com/12881364/212740267-e4f30af4-d565-402e-8b5d-1a66f6bab778.png)

You can see now maestro is able to access the button inside and now you can simply say:

```
- tapOn: 
    text: "I'm a small button"
    retryTapIfNoChange: false
```

Recording:

https://user-images.githubusercontent.com/12881364/212740946-07fdb1f5-b9de-42d3-88f7-9fe8fe6df7e8.mp4


Can you try this on your end? Let me know if this works.

We will update the docs as well on our end.
